### PR TITLE
Update FixedSidebarSplitViewController.m

### DIFF
--- a/SplitViewSidebar/FixedSidebarSplitViewController.m
+++ b/SplitViewSidebar/FixedSidebarSplitViewController.m
@@ -83,5 +83,14 @@
  
  */
 
+// There's a bug in the superclass; it doesn't check the splitViewItems count and so it'll crash if autolayout happens before viewDidLoad. This could happen if your window has a toolbar.
+- (BOOL)splitView:(NSSplitView *)splitView
+shouldHideDividerAtIndex:(NSInteger)dividerIndex {
+    if ([self.splitViewItems count] == 0) {
+        return NO;
+    }
+    return [super splitView:splitView shouldHideDividerAtIndex:dividerIndex];
+}
+
 
 @end


### PR DESCRIPTION
There's a bug in the superclass; it doesn't check the splitViewItems count and so it'll crash with an array range error if autolayout happens before viewDidLoad. This could happen if your window has a toolbar. Filed FB11980648 with Apple, meanwhile here's a workaround.